### PR TITLE
Correctly select sidebar containers for reordering

### DIFF
--- a/style.css
+++ b/style.css
@@ -2051,11 +2051,11 @@ html[xmlns] .clearfix {
     flex-direction: row;
   }
 
-  .sidebarPage :nth-child(1) {
+  .sidebarPage > .sidebarLeft {
     order: 2;
   }
 
-  .sidebarPage :nth-child(2) {
+  .sidebarPage > .sidebarRight {
     order: 1;
   }
 


### PR DESCRIPTION
### Description
This fixes #12 where wp-block-column elements were not displayed in the correct order.

### Compatibilities issues
None.

### Testing details
See issue.

### Checklist
- [x] The changes are fully tested.
