### PR TITLE
Make Dashicons available in the front-end

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -46,6 +46,9 @@ function enqueue_theme_css_js() {
     array('jquery'),
     wp_get_theme()->get('Version')
   );
+
+  /* Make Dashicons available in the front-end */
+  wp_enqueue_style('dashicons');
 }
 
 add_action('wp_enqueue_scripts', 'enqueue_theme_css_js');


### PR DESCRIPTION
<!-- Thanks for contributing to the SLRG WordPress Theme. -->

### Description
This PR makes [Dashicons](https://developer.wordpress.org/resource/dashicons) (the official WordPress icon font) available in the front-end.
As a result, the icons can be used on the pages, for example as follows:

```html
<i class="dashicons-before dashicons-pdf"></i> <a href="#">Downloadable resource</a>
```
<img width="237" alt="Screenshot 2021-12-14 at 20 08 27" src="https://user-images.githubusercontent.com/53262016/146063552-ea22e656-f7cb-4688-9516-5baa61c9d4fd.png">

### Compatibilities issues
None

### Testing details
None

### Checklist
- [x] The changes are fully tested.
